### PR TITLE
always use authorization rather than authentication

### DIFF
--- a/silopub/blogger.py
+++ b/silopub/blogger.py
@@ -32,7 +32,7 @@ def authorize():
 @blogger.route('/blogger/callback')
 def callback():
     redirect_uri = url_for('.callback', _external=True)
-    result = process_authenticate_callback(redirect_uri)
+    result = process_callback(redirect_uri)
 
     if 'error' in result:
         flash(result['error'], category='danger')
@@ -82,7 +82,7 @@ def callback():
                             user_id=account.user_id))
 
 
-def get_authorize_url(redirect_uri):
+def get_authorize_url(redirect_uri, **kwargs):
     csrf_token = generate_csrf()
     return API_AUTH_URL + '?' + urllib.parse.urlencode({
         'response_type': 'code',
@@ -95,18 +95,7 @@ def get_authorize_url(redirect_uri):
     })
 
 
-def get_authenticate_url(redirect_uri, **kwargs):
-    csrf_token = generate_csrf()
-    return API_AUTH_URL + '?' + urllib.parse.urlencode({
-        'response_type': 'code',
-        'client_id': current_app.config['GOOGLE_CLIENT_ID'],
-        'redirect_uri': redirect_uri,
-        'scope': BLOGGER_SCOPE,
-        'state': csrf_token,
-    })
-
-
-def process_authenticate_callback(redirect_uri):
+def process_callback(redirect_uri):
     code = request.args.get('code')
     error = request.args.get('error')
 

--- a/silopub/facebook.py
+++ b/silopub/facebook.py
@@ -53,7 +53,7 @@ def authorize():
 @facebook.route('/facebook/callback')
 def callback():
     callback_uri = url_for('.callback', _external=True)
-    result = process_authenticate_callback(callback_uri)
+    result = process_callback(callback_uri)
     if 'error' in result:
         flash(result['error'], category='danger')
         return redirect(url_for('views.index'))
@@ -83,14 +83,6 @@ def callback():
                             user_id=account.user_id))
 
 
-def get_authenticate_url(callback_uri, **kwargs):
-    return 'https://www.facebook.com/dialog/oauth?' + urlencode({
-        'client_id': current_app.config['FACEBOOK_CLIENT_ID'],
-        'redirect_uri': callback_uri,
-        'state': generate_csrf(),
-    })
-
-
 def get_authorize_url(callback_uri):
     return 'https://graph.facebook.com/oauth/authorize?' + urlencode({
         'client_id': current_app.config['FACEBOOK_CLIENT_ID'],
@@ -100,7 +92,7 @@ def get_authorize_url(callback_uri):
     })
 
 
-def process_authenticate_callback(callback_uri):
+def process_callback(callback_uri):
     code = request.args.get('code')
     state = request.args.get('state')
     error = request.args.get('error')

--- a/silopub/facebook.py
+++ b/silopub/facebook.py
@@ -25,17 +25,23 @@ def proxy_homepage(user_id):
     account = Account.query.filter_by(
         service=SERVICE_NAME, user_id=user_id).first()
 
-    if not account:
-        abort(404)
+    params = {
+        'service_name': 'Facebook',
+        'service_url': 'https://www.facebook.com/',
+        'service_photo': 'https://static.xx.fbcdn.net/rsrc.php/yl/r/H3nktOa7ZMg.ico',
+    }
 
-    info = account.user_info or {}
-    return util.render_proxy_homepage(
-        user_name=info.get('name') or account.username,
-        user_url=account.sites[0].url,
-        user_photo=info.get('picture', {}).get('data', {}).get('url'),
-        service_name='Facebook',
-        service_url='https://www.facebook.com/',
-        service_photo='https://static.xx.fbcdn.net/rsrc.php/yl/r/H3nktOa7ZMg.ico')
+    if account:
+        info = account.user_info or {}
+        params.update({
+            'user_name': info.get('name') or account.username,
+            'user_url': account.sites[0].url,
+            'user_photo': info.get('picture', {}).get('data', {}).get('url'),
+        })
+    else:
+        params['user_name'] = user_id
+
+    return util.render_proxy_homepage(**params)
 
 
 @facebook.route('/facebook/authorize', methods=['POST'])
@@ -54,36 +60,17 @@ def authorize():
 def callback():
     callback_uri = url_for('.callback', _external=True)
     result = process_callback(callback_uri)
+
     if 'error' in result:
         flash(result['error'], category='danger')
         return redirect(url_for('views.index'))
-    account = Account.query.filter_by(
-        service='facebook', user_id=result['user_id']).first()
 
-    if not account:
-        account = Account(service='facebook', user_id=result['user_id'],
-                          username=result['user_id'])
-        db.session.add(account)
-
-    account.user_info = result['user_info']
-    account.token = result['token']
-
-    account.update_sites([Facebook(
-        url='https://www.facebook.com/{}'.format(account.user_id),
-        # overloading "domain" to really mean "user's canonical url"
-        domain='facebook.com/{}'.format(account.user_id),
-        site_id=account.user_id)])
-
-    db.session.commit()
-    flash('Authorized {}: {}'.format(account.username, ', '.join(
-        s.domain for s in account.sites)))
-    util.set_authed(account.sites)
-
+    account = result['account']
     return redirect(url_for('views.setup_account', service=SERVICE_NAME,
                             user_id=account.user_id))
 
 
-def get_authorize_url(callback_uri):
+def get_authorize_url(callback_uri, **kwargs):
     return 'https://graph.facebook.com/oauth/authorize?' + urlencode({
         'client_id': current_app.config['FACEBOOK_CLIENT_ID'],
         'redirect_uri': callback_uri,
@@ -138,12 +125,28 @@ def process_callback(callback_uri):
 
     user_info = r.json()
     current_app.logger.debug('authed user info from Facebook %s', user_info)
-    return {
-        'token': access_token,
-        'user_id': user_info.get('id'),
-        'username': user_info.get('name'),
-        'user_info': user_info,
-    }
+
+    user_id = user_info.get('id')
+    account = Account.query.filter_by(
+        service='facebook', user_id=user_id).first()
+
+    if not account:
+        account = Account(service='facebook', user_id=user_id,
+                          username=user_id)
+        db.session.add(account)
+
+    account.user_info = user_info
+    account.token = access_token
+
+    account.update_sites([Facebook(
+        url='https://www.facebook.com/{}'.format(account.user_id),
+        # overloading "domain" to really mean "user's canonical url"
+        domain='facebook.com/{}'.format(account.user_id),
+        site_id=account.user_id)])
+
+    db.session.commit()
+    util.set_authed(account.sites)
+    return {'account': account}
 
 
 @facebook.route('/facebook/username', methods=['POST'])

--- a/silopub/flickr.py
+++ b/silopub/flickr.py
@@ -77,7 +77,7 @@ def authorize():
 def callback():
     try:
         callback_uri = url_for('.callback', _external=True)
-        result = process_authenticate_callback(callback_uri)
+        result = process_callback(callback_uri)
         if 'error' in result:
             flash(result['error'], category='danger')
             return redirect(url_for('views.index'))
@@ -132,7 +132,7 @@ def get_authorize_url(callback_uri):
     return oauth.authorization_url(AUTHORIZE_URL, perms='write')
 
 
-def process_authenticate_callback(callback_uri):
+def process_callback(callback_uri):
     verifier = request.args.get('oauth_verifier')
     request_token = request.args.get('oauth_token')
     if not verifier or not request_token:

--- a/silopub/goodreads.py
+++ b/silopub/goodreads.py
@@ -68,7 +68,7 @@ def authorize():
 def callback():
     try:
         callback_uri = url_for('.callback', _external=True)
-        result = process_authenticate_callback(callback_uri)
+        result = process_callback(callback_uri)
 
         if 'error' in result:
             flash(result['error'], category='danger')
@@ -122,12 +122,7 @@ def get_authorize_url(callback_uri):
         }))
 
 
-def get_authenticate_url(callback_uri, **kwargs):
-    # goodreads doesn't have a separate authenticate endpoint
-    return get_authorize_url(callback_uri)
-
-
-def process_authenticate_callback(callback_uri):
+def process_callback(callback_uri):
     if request.args.get('authorize') != '1':
         return {'error': 'Goodreads user declined'}
 

--- a/silopub/test_twitter.py
+++ b/silopub/test_twitter.py
@@ -48,7 +48,7 @@ class TestTwitter(SiloPubTestCase):
 
     @patch('requests.get')
     @patch('requests_oauthlib.OAuth1Session.fetch_access_token')
-    def test_process_authenticate_callback(self, fetch_access_token, getter):
+    def test_process_callback(self, fetch_access_token, getter):
         with self.app.test_request_context():
             session['oauth_token_secret'] = '456'
             request.url = '/callback?oauth_token=123&oauth_verifier=789'
@@ -63,7 +63,7 @@ class TestTwitter(SiloPubTestCase):
                 'extra_info': 'Hi',
             }))
 
-            result = twitter.process_authenticate_callback(CALLBACK_URI)
+            result = twitter.process_callback(CALLBACK_URI)
             self.assertEqual({
                 'token': '123',
                 'secret': '456',

--- a/silopub/tumblr.py
+++ b/silopub/tumblr.py
@@ -39,32 +39,9 @@ def callback():
         if 'error' in result:
             flash(result['error'], category='danger')
             return redirect(url_for('views.index'))
-
-        account = Account.query.filter_by(
-            service='tumblr', user_id=result['user_id']).first()
-
-        if not account:
-            account = Account(service='tumblr', user_id=result['user_id'])
-            db.session.add(account)
-
-        account.username = result['username']
-        account.user_info = result['user_info']
-        account.token = result['token']
-        account.token_secret = result['secret']
-
-        sites = []
-        for blog in result['user_info'].get('blogs', []):
-            sites.append(Tumblr(
-                url=blog.get('url'),
-                domain=util.domain_for_url(blog.get('url')),
-                site_id=blog.get('name'),
-                site_info=blog))
-        account.update_sites(sites)
-
-        db.session.commit()
+        account = result['account']
         flash('Authorized {}: {}'.format(account.username, ', '.join(
             s.domain for s in account.sites)))
-        util.set_authed(account.sites)
         return redirect(url_for('views.setup_account', service=SERVICE_NAME,
                                 user_id=account.user_id))
 
@@ -97,13 +74,30 @@ def process_callback(callback_uri):
     user_info = info_resp.get('response', {}).get('user')
     user_id = username = user_info.get('name')
 
-    return {
-        'token': token,
-        'secret': secret,
-        'user_id': user_id,
-        'username': username,
-        'user_info': user_info,
-    }
+    account = Account.query.filter_by(
+        service='tumblr', user_id=user_id).first()
+
+    if not account:
+        account = Account(service='tumblr', user_id=user_id)
+        db.session.add(account)
+
+    account.username = username
+    account.user_info = user_info
+    account.token = token
+    account.token_secret = secret
+
+    sites = []
+    for blog in user_info.get('blogs', []):
+        sites.append(Tumblr(
+            url=blog.get('url'),
+            domain=util.domain_for_url(blog.get('url')),
+            site_id=blog.get('name'),
+            site_info=blog))
+    account.update_sites(sites)
+
+    db.session.commit()
+    util.set_authed(account.sites)
+    return {'account': account}
 
 
 def publish(site):

--- a/silopub/tumblr.py
+++ b/silopub/tumblr.py
@@ -35,7 +35,7 @@ def authorize():
 def callback():
     try:
         callback_uri = url_for('.callback', _external=True)
-        result = process_authenticate_callback(callback_uri)
+        result = process_callback(callback_uri)
         if 'error' in result:
             flash(result['error'], category='danger')
             return redirect(url_for('views.index'))
@@ -74,18 +74,7 @@ def callback():
         return redirect(url_for('views.index'))
 
 
-def get_authenticate_url(callback_uri, **kwargs):
-    # Tumblr only has authorize, no authenticate
-    oauth = OAuth1Session(
-        client_key=current_app.config['TUMBLR_CLIENT_KEY'],
-        client_secret=current_app.config['TUMBLR_CLIENT_SECRET'],
-        callback_uri=callback_uri)
-    r = oauth.fetch_request_token(REQUEST_TOKEN_URL)
-    session['oauth_token_secret'] = r.get('oauth_token_secret')
-    return oauth.authorization_url(AUTHORIZE_URL)
-
-
-def process_authenticate_callback(callback_uri):
+def process_callback(callback_uri):
     verifier = request.args.get('oauth_verifier')
     request_token = request.args.get('oauth_token')
     if not verifier or not request_token:

--- a/silopub/twitter.py
+++ b/silopub/twitter.py
@@ -39,16 +39,25 @@ def proxy_homepage(username):
     account = Account.query.filter_by(
         service=SERVICE_NAME, username=username).first()
 
-    if not account:
-        abort(404)
+    params = {
+        'service_name': 'Twitter',
+        'service_url': 'https://twitter.com/',
+        'service_photo': 'https://abs.twimg.com/favicons/favicon.ico'
+    }
 
-    return util.render_proxy_homepage(
-        user_name='@' + account.username,
-        user_url=account.sites[0].url,
-        user_photo=(account.user_info or {}).get('profile_image_url_https'),
-        service_name='Twitter',
-        service_url='https://twitter.com/',
-        service_photo='https://abs.twimg.com/favicons/favicon.ico')
+    if account:
+        params.update({
+            'user_name': '@' + account.username,
+            'user_url': account.sites[0].url,
+            'user_photo': (account.user_info or {}).get('profile_image_url_https'),
+        })
+    else:
+        params.update({
+            'user_name': '@' + username,
+            'user_url': 'https://twitter.com/' + username,
+        })
+
+    return util.render_proxy_homepage(SERVICE_NAME, **params)
 
 
 @twitter.route('/twitter/authorize', methods=['POST'])
@@ -66,32 +75,11 @@ def authorize():
 def callback():
     try:
         callback_uri = url_for('.callback', _external=True)
-        result = process_authenticate_callback(callback_uri)
+        account, error = process_callback(callback_uri)
         if 'error' in result:
             flash(result['error'], category='danger')
             return redirect(url_for('views.index'))
 
-        account = Account.query.filter_by(
-            service='twitter', user_id=result['user_id']).first()
-
-        if not account:
-            account = Account(service='twitter', user_id=result['user_id'])
-            db.session.add(account)
-
-        account.username = result['username']
-        account.user_info = result['user_info']
-        account.token = result['token']
-        account.token_secret = result['secret']
-
-        account.update_sites([Twitter(
-            url='https://twitter.com/{}'.format(account.username),
-            domain='twitter.com/{}'.format(account.username),
-            site_id=account.user_id)])
-
-        db.session.commit()
-        flash('Authorized {}: {}'.format(account.username, ', '.join(
-            s.domain for s in account.sites)))
-        util.set_authed(account.sites)
         return redirect(url_for('views.setup_account', service=SERVICE_NAME,
                                 user_id=account.user_id))
 
@@ -101,45 +89,29 @@ def callback():
         return redirect(url_for('views.index'))
 
 
-def get_authenticate_url(callback_uri, me=None, **kwargs):
+def get_authorize_url(callback_uri, me=None, **kwargs):
     session.pop('oauth_token', None)
     session.pop('oauth_token_secret', None)
     oauth_session = OAuth1Session(
         client_key=current_app.config['TWITTER_CLIENT_KEY'],
         client_secret=current_app.config['TWITTER_CLIENT_SECRET'],
         callback_uri=callback_uri)
+
     r = oauth_session.fetch_request_token(REQUEST_TOKEN_URL)
     session['oauth_token'] = r.get('oauth_token')
     session['oauth_token_secret'] = r.get('oauth_token_secret')
-
     params = {'force_login': 'true'}
     if me:
         params['screen_name'] = me.split('/')[-1]
     return oauth_session.authorization_url(
-        AUTHENTICATE_URL + '?' + urllib.parse.urlencode(params))
-
-
-def get_authorize_url(callback_uri):
-    session.pop('oauth_token', None)
-    session.pop('oauth_token_secret', None)
-    oauth_session = OAuth1Session(
-        client_key=current_app.config['TWITTER_CLIENT_KEY'],
-        client_secret=current_app.config['TWITTER_CLIENT_SECRET'],
-        callback_uri=callback_uri)
-
-    r = oauth_session.fetch_request_token(REQUEST_TOKEN_URL)
-    session['oauth_token'] = r.get('oauth_token')
-    session['oauth_token_secret'] = r.get('oauth_token_secret')
-    params = {'force_login': 'true'}
-    return oauth_session.authorization_url(
         AUTHORIZE_URL + '?' + urllib.parse.urlencode(params))
 
 
-def process_authenticate_callback(callback_uri):
+def process_callback(callback_uri):
     verifier = request.args.get('oauth_verifier')
     if not verifier:
         # user declined
-        return {'error': 'Twitter authorization declined'}
+        return None, 'Twitter authorization declined'
 
     request_token = session.get('oauth_token')
     request_token_secret = session.get('oauth_token_secret')
@@ -169,7 +141,7 @@ def process_authenticate_callback(callback_uri):
     user_info = requests.get(VERIFY_CREDENTIALS_URL, auth=auth).json()
 
     if 'errors' in user_info:
-        return {'error': 'Error fetching credentials %r' % user_info.get('errors')}
+        return None, 'Error fetching credentials %r' % user_info.get('errors')
 
     user_id = user_info.get('id_str')
     username = user_info.get('screen_name')
@@ -178,13 +150,29 @@ def process_authenticate_callback(callback_uri):
                              user_id, username)
     current_app.logger.debug('user_info: %r', user_info)
 
-    return {
-        'token': access_token,
-        'secret': access_token_secret,
-        'user_id': user_id,
-        'username': username,
-        'user_info': user_info,
-    }
+    account = Account.query.filter_by(
+        service='twitter', user_id=user_id).first()
+
+    if not account:
+        account = Account(service='twitter', user_id=user_id)
+        db.session.add(account)
+
+    account.username = username
+    account.user_info = user_info
+    account.token = access_token
+    account.token_secret = access_token_secret
+
+    account.update_sites([Twitter(
+        url='https://twitter.com/{}'.format(account.username),
+        domain='twitter.com/{}'.format(account.username),
+        site_id=account.user_id)])
+
+    db.session.commit()
+    flash('Authorized {}: {}'.format(account.username, ', '.join(
+        s.domain for s in account.sites)))
+    util.set_authed(account.sites)
+
+    return account, None
 
 
 def publish(site):

--- a/silopub/util.py
+++ b/silopub/util.py
@@ -140,8 +140,8 @@ def posse_post_discovery(original, regex):
         current_app.logger.exception('MF2 Parser error: %s', e)
 
 
-def render_proxy_homepage(user_name, user_url, user_photo,
-                          service_name, service_url, service_photo):
+def render_proxy_homepage(service, user_name='', user_url='', user_photo='',
+                          service_name='', service_url='', service_photo=''):
     # TODO make endpoints visible because why not
     return """
 <!DOCTYPE html>
@@ -170,7 +170,7 @@ def render_proxy_homepage(user_name, user_url, user_photo,
         </div>
     </body>
 </html>""".format(
-    auth=url_for('micropub.indieauth', _external=True),
+    auth=url_for('micropub.indieauth', service=service, _external=True),
     token=url_for('micropub.token_endpoint', _external=True),
     micropub=url_for('micropub.micropub_endpoint', _external=True),
     user_name=user_name, user_url=user_url, user_photo=user_photo,

--- a/silopub/util.py
+++ b/silopub/util.py
@@ -4,6 +4,7 @@ import re
 import urllib.parse
 
 from flask import flash, current_app, make_response, url_for, jsonify, session
+from flask import request
 from requests.exceptions import HTTPError, SSLError
 import jwt
 import mf2py
@@ -140,7 +141,7 @@ def posse_post_discovery(original, regex):
         current_app.logger.exception('MF2 Parser error: %s', e)
 
 
-def render_proxy_homepage(service, user_name='', user_url='', user_photo='',
+def render_proxy_homepage(user_name='', user_url='', user_photo='',
                           service_name='', service_url='', service_photo=''):
     # TODO make endpoints visible because why not
     return """
@@ -170,7 +171,7 @@ def render_proxy_homepage(service, user_name='', user_url='', user_photo='',
         </div>
     </body>
 </html>""".format(
-    auth=url_for('micropub.indieauth', service=service, _external=True),
+    auth=url_for('micropub.indieauth', _external=True),
     token=url_for('micropub.token_endpoint', _external=True),
     micropub=url_for('micropub.micropub_endpoint', _external=True),
     user_name=user_name, user_url=user_url, user_photo=user_photo,

--- a/silopub/wordpress.py
+++ b/silopub/wordpress.py
@@ -31,79 +31,20 @@ wordpress = Blueprint('wordpress', __name__)
 @wordpress.route('/wordpress/authorize', methods=['POST'])
 def authorize():
     redirect_uri = url_for('.callback', _external=True)
-    client_id = current_app.config['WORDPRESS_CLIENT_ID']
-
     return redirect(get_authorize_url(redirect_uri))
 
 
 @wordpress.route('/wordpress/callback')
 def callback():
-    state = request.args.get('state', '')
-    csrf, purpose = state.split('|', 1)
-
-    # wordpress only allows us one redirect url, so use the state parameter to
-    # hack it to redirect to another one
-    if purpose == 'id':
-        return redirect(url_for(
-            'micropub.indieauth_callback',
-            code=request.args.get('code'),
-            error=request.args.get('error'),
-            error_description=request.args.get('error_description'),
-            state=state))
-
-    redirect_uri = url_for('wordpress.callback', _external=True)
+    redirect_uri = url_for('.callback', _external=True)
     result = process_callback(redirect_uri)
 
     if 'error' in result:
         flash(result['error'], category='danger')
         return redirect(url_for('views.index'))
 
-    access_token = result['token']
-    username = result['username']
-    user_id = result['user_id']
-    user_info = result['user_info']
-    blog_id = result['blog_id']
-    blog_url = result['blog_url']
-
-    account = Account.query.filter_by(
-        service=SERVICE_NAME, user_id=user_id).first()
-    if not account:
-        account = Account(service=SERVICE_NAME, user_id=user_id)
-    account.username = username
-    account.user_info = user_info
-
-    current_app.logger.info(
-        'Fetching site info %s', API_SITE_URL.format(blog_id))
-    r = requests.get(API_SITE_URL.format(blog_id), headers={
-        'Authorization': 'Bearer ' + access_token})
-    current_app.logger.info('Site info response %s', r)
-
-    if r.status_code // 100 != 2:
-        error_obj = r.json()
-        flash('Error ({}) fetching site info: {}, description: {}'.format(
-            r.status_code, error_obj.get('error'),
-            error_obj.get('error_description')), 'danger')
-        return redirect(url_for('views.index'))
-
-    site = Wordpress.query.filter_by(
-        account=account, site_id=blog_id).first()
-    if not site:
-        site = Wordpress(site_id=blog_id)
-        account.sites.append(site)
-
-    site.site_info = r.json()
-    site.url = blog_url
-    site.domain = util.domain_for_url(blog_url)
-    site.token = access_token
-
-    db.session.add(account)
-    db.session.commit()
-
-    flash('Authorized {}: {}'.format(account.username, site.domain))
-    util.set_authed([site])
-
     return redirect(url_for('views.setup_site', service=SERVICE_NAME,
-                            domain=site.domain))
+                            domain=result['site'].domain))
 
 
 def get_authorize_url(callback_uri, me=None, **kwargs):
@@ -113,9 +54,9 @@ def get_authorize_url(callback_uri, me=None, **kwargs):
 
     params = {
         'client_id': client_id,
-        'redirect_uri': url_for('wordpress.callback', _external=True),
+        'redirect_uri': callback_uri,
         'response_type': 'code',
-        'state': generate_csrf() + '|auth',
+        'state': generate_csrf(),
     }
     if me:
         params['blog'] = me
@@ -124,18 +65,16 @@ def get_authorize_url(callback_uri, me=None, **kwargs):
 
 
 def process_callback(callback_uri):
-    # ignore the callback uri because wp only lets us define one
     client_id = current_app.config['WORDPRESS_CLIENT_ID']
     client_secret = current_app.config['WORDPRESS_CLIENT_SECRET']
-    redirect_uri = url_for('wordpress.callback', _external=True),
 
     code = request.args.get('code')
     error = request.args.get('error')
     error_desc = request.args.get('error_description')
-    csrf, purpose = request.args.get('state', '').split('|', 1)
+    csrf = request.args.get('state', '')
 
     if error:
-        return {'error': 'Wordpress authorization canceled or failed with '
+        return {'error':  'Wordpress authorization canceled or failed with '
                 'error: {}, and description: {}' .format(error, error_desc)}
 
     if not validate_csrf(csrf):
@@ -143,7 +82,7 @@ def process_callback(callback_uri):
 
     r = requests.post(API_TOKEN_URL, data={
         'client_id': client_id,
-        'redirect_uri': redirect_uri,
+        'redirect_uri': callback_uri,
         'client_secret': client_secret,
         'code': code,
         'grant_type': 'authorization_code',
@@ -153,8 +92,12 @@ def process_callback(callback_uri):
         error_obj = r.json()
         return {
             'error': 'Error ({}) requesting access token: {}, description: {}'
-            .format(r.status_code, error_obj.get('error'),
-                    error_obj.get('error_description'))}
+            .format(
+                r.status_code,
+                error_obj.get('error'),
+                error_obj.get('error_description')
+            ),
+        }
 
     payload = r.json()
     current_app.logger.info('WordPress token endpoint repsonse: %r', payload)
@@ -177,14 +120,41 @@ def process_callback(callback_uri):
     user_id = str(user_info.get('ID'))
     username = user_info.get('username')
 
-    return {
-        'token': access_token,
-        'blog_id': blog_id,
-        'blog_url': blog_url,
-        'user_id': user_id,
-        'username': username,
-        'user_info': user_info,
-    }
+    account = Account.query.filter_by(
+        service=SERVICE_NAME, user_id=user_id).first()
+    if not account:
+        account = Account(service=SERVICE_NAME, user_id=user_id)
+    account.username = username
+    account.user_info = user_info
+
+    current_app.logger.info(
+        'Fetching site info %s', API_SITE_URL.format(blog_id))
+    r = requests.get(API_SITE_URL.format(blog_id), headers={
+        'Authorization': 'Bearer ' + access_token})
+    current_app.logger.info('Site info response %s', r)
+
+    if r.status_code // 100 != 2:
+        error_obj = r.json()
+        return {'error': 'Error ({}) fetching site info: {}, description: {}'
+                .format(r.status_code, error_obj.get('error'),
+                        error_obj.get('error_description'))}
+
+    site = Wordpress.query.filter_by(
+        account=account, site_id=blog_id).first()
+    if not site:
+        site = Wordpress(site_id=blog_id)
+        account.sites.append(site)
+
+    site.site_info = r.json()
+    site.url = blog_url
+    site.domain = util.domain_for_url(blog_url)
+    site.token = access_token
+
+    db.session.add(account)
+    db.session.commit()
+
+    util.set_authed([site])
+    return {'account': account}
 
 
 def publish(site):


### PR DESCRIPTION
and create accounts the first time they auth (whether directly via silo.pub, or indirectly via indieauth)

If someone indieauths in with a new, never-before-seen URL, we'll do our best to guess what service it belongs to.

Wordpress no longer needs a hack to multiplex two callbacks -- we can provide the callback via param.
