### PR TITLE
increase shortening length to 280 characters

### DIFF
--- a/silopub/templates/developers.jinja2
+++ b/silopub/templates/developers.jinja2
@@ -237,7 +237,7 @@
         </tr>
         <tr>
           <td>content[value] or content</td>
-          <td>text of the note. If this is longer than 140 characters
+          <td>text of the note. If this is longer than 280 characters
             (assuming t.co wrapping), silo.pub will automatically truncate
             the content and include <code>url</code> (if provided)</td>
         </tr>

--- a/silopub/twitter.py
+++ b/silopub/twitter.py
@@ -341,7 +341,7 @@ def publish(site):
 
     if content:
         data['status'] = brevity.shorten(content, permalink=permalink_url,
-                                         format=format)
+                                         format=format, target_length=280)
     data = util.trim_nulls(data)
     current_app.logger.debug('publishing with params %s', data)
     return interpret_response(


### PR DESCRIPTION
I did this in silo.pub instead of brevity since I don't really know how to manage python dependencies