### PR TITLE
update uwsgi for new openssl

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -17,7 +17,7 @@ requests==2.11.1
 requests-oauthlib==0.7.0
 six==1.10.0
 SQLAlchemy==1.1.2
-uWSGI==2.0.14
+uWSGI==2.0.15
 Werkzeug==0.11.11
 wheel==0.29.0
 WTForms==2.1


### PR DESCRIPTION
uwsgi 2.0.14 fails on openssl 1.1.0 (Ubuntu 16.04)