### PR TITLE
updates for twitter replies

### DIFF
--- a/silopub/templates/developers.jinja2
+++ b/silopub/templates/developers.jinja2
@@ -21,7 +21,7 @@
     <div class="section">
       <h2 id="micropub">Micropub</h2>
       <p>
-        <a href="https://indiewebcamp.com/Micropub">Micropub</a> is an
+        <a href="https://indieweb.org/Micropub">Micropub</a> is an
         open API standard that describes a protocol for publishing to a
         personal website. The protocol includes OAuth2-style authorization,
         using your website's URL as your ID.
@@ -30,7 +30,7 @@
         silo.pub exposes a micropub endpoint so you can use this
         protocol and vocabulary to publish to many different hosted
         services like Blogger and Twitter. If you are
-        <a href="https://indiewebcamp.com/POSSE">POSSEing</a> to many
+        <a href="https://indieweb.org/POSSE">POSSEing</a> to many
         different services, silo.pub might save you the trouble of
         writing special code for each unique API.
       </p>
@@ -243,11 +243,7 @@
         </tr>
         <tr>
           <td>in-reply-to</td>
-          <td>URL of a tweet to reply to. If the repliee is not the
-            currently authorized user, and the post content does not
-            include the @-name of the repliee, it will automatically be
-            prepended to the string (otherwise Twitter does not recognize
-            it as a reply). Use in-reply-to[] to pass multiple
+          <td>URL of a tweet to reply to. Use in-reply-to[] to pass multiple
             values &mdash; We'll use the first one that looks like a tweet
             permalink.</td>
         </tr>

--- a/silopub/twitter.py
+++ b/silopub/twitter.py
@@ -323,9 +323,6 @@ def publish(site):
         twitterer, tweet_id = get_tweet_id(in_reply_to)
         if tweet_id:
             data['in_reply_to_status_id'] = tweet_id
-            if (twitterer != site.account.username and
-                    '@' + twitterer.lower() not in content.lower()):
-                content = '@{} {}'.format(twitterer, content)
             break
     else:
         if in_reply_tos:


### PR DESCRIPTION
Twitter no longer requires replies to start with the username of the person you're replying to since the API prepends this information automatically.